### PR TITLE
Fix obtaining a window memory attribution token

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -680,16 +680,16 @@ Creating or obtaining a memory attribution token {#creating-or-obtaining-a-memor
       1. Return a new [=/memory attribution token=] whose:
           - [=memory attribution token/container=] is null,
           - [=memory attribution token/cross-origin aggregated flag=] is false.
+  1. If |parent origin| is not equal to |top-level origin|, then:
+      1. Return |parent token|.
   1. Let |container| be the result of [=extracting container element attributes=] given |container element|.
   1. If |origin| is equal to |top-level origin|, then:
       1. Return a new [=/memory attribution token=] whose:
           - [=memory attribution token/container=] is |container|,
           - [=memory attribution token/cross-origin aggregated flag=] is false.
-  1. If |parent origin| is equal to |top-level origin|, then:
-      1. Return a new [=/memory attribution token=] whose:
-          - [=memory attribution token/container=] is |container|,
-          - [=memory attribution token/cross-origin aggregated flag=] is true.
-  1. Return |parent token|.
+  1. Return a new [=/memory attribution token=] whose:
+      - [=memory attribution token/container=] is |container|,
+      - [=memory attribution token/cross-origin aggregated flag=] is true.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
We need to first check if the parent is cross-origin so
that an same-origin iframe embedded in a cross-origin iframe
does not expose its iframe attributes.

Issue: #17