### PR TITLE
Add Exposed attribute to the API

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -710,7 +710,7 @@ Extensions to the {{Performance}} interface {#extensions-to-performance}
 
 <pre class="idl">
 partial interface Performance {
-  [Exposed=(Window,ServiceWorker,SharedWorker) CrossOriginIsolated] Promise&lt;MemoryMeasurement&gt; measureUserAgentSpecificMemory();
+  [Exposed=(Window,ServiceWorker,SharedWorker), CrossOriginIsolated] Promise&lt;MemoryMeasurement&gt; measureUserAgentSpecificMemory();
 };
 </pre>
 <dl class="domintro">

--- a/index.src.html
+++ b/index.src.html
@@ -710,7 +710,7 @@ Extensions to the {{Performance}} interface {#extensions-to-performance}
 
 <pre class="idl">
 partial interface Performance {
-  [CrossOriginIsolated] Promise&lt;MemoryMeasurement&gt; measureUserAgentSpecificMemory();
+  [Exposed=(Window,ServiceWorker,SharedWorker) CrossOriginIsolated] Promise&lt;MemoryMeasurement&gt; measureUserAgentSpecificMemory();
 };
 </pre>
 <dl class="domintro">


### PR DESCRIPTION
This adds the missing Exposed attribute to specify that the API
is exposed only in Window, ServiceWorker, and SharedWorker.